### PR TITLE
changes to Component.CoreEditor prerequisites

### DIFF
--- a/vsixTemplatePackSideWaffle/source.extension.vsixmanifest
+++ b/vsixTemplatePackSideWaffle/source.extension.vsixmanifest
@@ -19,7 +19,7 @@
         <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
     </Dependencies>
     <Prerequisites>
-        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,)" DisplayName="Visual Studio core editor" />
     </Prerequisites>
     <Assets>
         <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />


### PR DESCRIPTION
With this prerequisites it is now compatible with VS2019. Without this change it errors out complaining about a not met prerequisites of Microsoft.VisualStudio.Component.CoreEditor. I changed it how https://devblogs.microsoft.com/visualstudio/how-to-upgrade-extensions-to-support-visual-studio-2019/ recommended it and now it properly installs on VS2019.